### PR TITLE
Fix bad texture coordinates in raster-12

### DIFF
--- a/demos/raster-06.html
+++ b/demos/raster-06.html
@@ -196,8 +196,8 @@ var triangles = [
   Triangle(5, 7, 6, BLUE),
   Triangle(1, 5, 6, YELLOW),
   Triangle(1, 6, 2, YELLOW),
-  Triangle(4, 5, 1, PURPLE),
-  Triangle(4, 1, 0, PURPLE),
+  Triangle(5, 1, 0, PURPLE),
+  Triangle(5, 0, 4, PURPLE),
   Triangle(2, 6, 7, CYAN),
   Triangle(2, 7, 3, CYAN)
 ];

--- a/demos/raster-07.html
+++ b/demos/raster-07.html
@@ -233,8 +233,8 @@ var triangles = [
   Triangle(5, 7, 6, BLUE),
   Triangle(1, 5, 6, YELLOW),
   Triangle(1, 6, 2, YELLOW),
-  Triangle(4, 5, 1, PURPLE),
-  Triangle(4, 1, 0, PURPLE),
+  Triangle(5, 1, 0, PURPLE),
+  Triangle(5, 0, 4, PURPLE),
   Triangle(2, 6, 7, CYAN),
   Triangle(2, 7, 3, CYAN)
 ];

--- a/demos/raster-08.html
+++ b/demos/raster-08.html
@@ -349,8 +349,8 @@ var triangles = [
   Triangle(5, 7, 6, BLUE),
   Triangle(1, 5, 6, YELLOW),
   Triangle(1, 6, 2, YELLOW),
-  Triangle(4, 5, 1, PURPLE),
-  Triangle(4, 1, 0, PURPLE),
+  Triangle(5, 1, 0, PURPLE),
+  Triangle(5, 0, 4, PURPLE),
   Triangle(2, 6, 7, CYAN),
   Triangle(2, 7, 3, CYAN)
 ];

--- a/demos/raster-09.html
+++ b/demos/raster-09.html
@@ -434,8 +434,8 @@ var triangles = [
   Triangle(5, 7, 6, BLUE),
   Triangle(1, 5, 6, YELLOW),
   Triangle(1, 6, 2, YELLOW),
-  Triangle(4, 5, 1, PURPLE),
-  Triangle(4, 1, 0, PURPLE),
+  Triangle(5, 1, 0, PURPLE),
+  Triangle(5, 0, 4, PURPLE),
   Triangle(2, 6, 7, CYAN),
   Triangle(2, 7, 3, CYAN)
 ];

--- a/demos/raster-10.html
+++ b/demos/raster-10.html
@@ -589,16 +589,16 @@ var CYAN = [0, 255, 255];
 var triangles = [
   Triangle([0, 1, 2], RED),
   Triangle([0, 2, 3], RED),
-  Triangle([1, 5, 6], YELLOW),
-  Triangle([1, 6, 2], YELLOW),
-  Triangle([2, 6, 7], CYAN),
-  Triangle([2, 7, 3], CYAN),
   Triangle([4, 0, 3], GREEN),
-  Triangle([4, 1, 0], PURPLE),
   Triangle([4, 3, 7], GREEN),
-  Triangle([4, 5, 1], PURPLE),
   Triangle([5, 4, 7], BLUE),
   Triangle([5, 7, 6], BLUE),
+  Triangle([1, 5, 6], YELLOW),
+  Triangle([1, 6, 2], YELLOW),
+  Triangle([5, 1, 0], PURPLE),
+  Triangle([5, 0, 4], PURPLE),
+  Triangle([2, 6, 7], CYAN),
+  Triangle([2, 7, 3], CYAN),
 ];
 
 Shuffle(triangles);

--- a/demos/raster-11.html
+++ b/demos/raster-11.html
@@ -786,7 +786,7 @@ var triangles = [
   Triangle([5, 7, 6], BLUE,   [Vertex(0, 0, -1), Vertex(0, 0, -1), Vertex(0, 0, -1)]),
   Triangle([1, 5, 6], YELLOW, [Vertex(-1, 0, 0), Vertex(-1, 0, 0), Vertex(-1, 0, 0)]),
   Triangle([1, 6, 2], YELLOW, [Vertex(-1, 0, 0), Vertex(-1, 0, 0), Vertex(-1, 0, 0)]),
-  Triangle([1, 0, 5], PURPLE, [Vertex(0, 1, 0), Vertex(0, 1, 0), Vertex(0, 1, 0)]),
+  Triangle([5, 1, 0], PURPLE, [Vertex(0, 1, 0), Vertex(0, 1, 0), Vertex(0, 1, 0)]),
   Triangle([5, 0, 4], PURPLE, [Vertex(0, 1, 0), Vertex(0, 1, 0), Vertex(0, 1, 0)]),
   Triangle([2, 6, 7], CYAN,   [Vertex(0, -1, 0), Vertex(0, -1, 0), Vertex(0, -1, 0)]),
   Triangle([2, 7, 3], CYAN,   [Vertex(0, -1, 0), Vertex(0, -1, 0), Vertex(0, -1, 0)])

--- a/demos/raster-12.html
+++ b/demos/raster-12.html
@@ -840,8 +840,8 @@ var triangles = [
   Triangle([5, 7, 6], BLUE,   [Vertex( 0,  0, -1), Vertex( 0,  0, -1), Vertex( 0,  0, -1)], wood_texture, [Pt(0, 0), Pt(1, 1), Pt(0, 1)]),
   Triangle([1, 5, 6], YELLOW, [Vertex(-1,  0,  0), Vertex(-1,  0,  0), Vertex(-1,  0,  0)], wood_texture, [Pt(0, 0), Pt(1, 0), Pt(1, 1)]),
   Triangle([1, 6, 2], YELLOW, [Vertex(-1,  0,  0), Vertex(-1,  0,  0), Vertex(-1,  0,  0)], wood_texture, [Pt(0, 0), Pt(1, 1), Pt(0, 1)]),
-  Triangle([1, 0, 5], PURPLE, [Vertex( 0,  1,  0), Vertex( 0,  1,  0), Vertex( 0,  1,  0)], wood_texture, [Pt(0, 0), Pt(1, 0), Pt(1, 1)]),
-  Triangle([5, 0, 4], PURPLE, [Vertex( 0,  1,  0), Vertex( 0,  1,  0), Vertex( 0,  1,  0)], wood_texture, [Pt(0, 1), Pt(1, 1), Pt(0, 0)]), 
+  Triangle([5, 1, 0], PURPLE, [Vertex( 0,  1,  0), Vertex( 0,  1,  0), Vertex( 0,  1,  0)], wood_texture, [Pt(0, 0), Pt(1, 0), Pt(1, 1)]),
+  Triangle([5, 0, 4], PURPLE, [Vertex( 0,  1,  0), Vertex( 0,  1,  0), Vertex( 0,  1,  0)], wood_texture, [Pt(0, 0), Pt(1, 1), Pt(0, 1)]),
   Triangle([2, 6, 7], CYAN,   [Vertex( 0, -1,  0), Vertex( 0, -1,  0), Vertex( 0, -1,  0)], wood_texture, [Pt(0, 0), Pt(1, 0), Pt(1, 1)]), 
   Triangle([2, 7, 3], CYAN,   [Vertex( 0, -1,  0), Vertex( 0, -1,  0), Vertex( 0, -1,  0)], wood_texture, [Pt(0, 0), Pt(1, 1), Pt(0, 1)]),
 ];


### PR DESCRIPTION
**Problem Description**

The Cube Model defines the triangle vertexes forming its top face in a different way to its other faces. It makes no difference for the demos where the cube faces are solid colors, but it is a problem in raster-12.html, when textures are introduced. It results in one of the top face triangles displaying the wrong part of the texture.

To see the problem, change the camera position on line 859 to:
`var camera = Camera(Vertex(-1.5, 2, 3.5), MakeOYRotationMatrix(0));`

You may also need to increase the ambient light on line 876 to better see the problem, e.g.:
`  Light(LT_AMBIENT, 0.6),`

It's easier to see if you add code to rotate the camera around the X axis so you can move it above the cube and point it down.

For the record, raster-06.html to raster-09.html use the same vertex code; raster-10.html reorders the lines of the code block, but the vertexes are unchanged; and raster-11.html and raster-12.html use the same order as raster-06.html to raster-09.html, but change the vertexes for both triangles of the purple (top) cube face.

**Fix in this PR**

This PR fixes the problem by reordering the triangle vertexes on the top cube face. Although the problem is only visible on raster-12.html, the PR makes similar changes to raster-06.html to raster-12.html so the definition of cube vertexes remains consistent. One disadvantage to this approach is that eagle-eyed readers may notice that the triangles defining cube tops are drawn from different corners than shown in the figures in chapters 10 and 11.

**Alternative Fix**

If you prefer a smaller workaround rather than this fix, reject this PR and correct what I believe was an attempt at a workaround for just raster-12.html. It reorders the **texture** coordinates (not the vertexes), on line 844, but it unfortunately modifies the wrong triangle. Undo the bad workaround and implement it correctly by changing lines 843 and 844 to:
```
  Triangle([1, 0, 5], PURPLE, [Vertex( 0,  1,  0), Vertex( 0,  1,  0), Vertex( 0,  1,  0)], wood_texture, [Pt(1, 0), Pt(1, 1), Pt(0, 0)]),
  Triangle([5, 0, 4], PURPLE, [Vertex( 0,  1,  0), Vertex( 0,  1,  0), Vertex( 0,  1,  0)], wood_texture, [Pt(0, 0), Pt(1, 1), Pt(0, 1)]),
```

In case you are wondering how I found the problem, it was because I was puzzled why the texture coordinates on line 844 of raster-12.html didn't follow the pattern of the other triangles.
